### PR TITLE
Add auth in Rewriter client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Adds `VtexIdclientAutCookie` to the headers when sending requests to the Rewriter app.
+
 ## [1.0.2] - 2025-09-02
 
 ### Fixed

--- a/src/clients/apps/Rewriter.ts
+++ b/src/clients/apps/Rewriter.ts
@@ -34,7 +34,11 @@ export class Rewriter extends AppGraphQLClient {
   constructor(context: IOContext, options: InstanceOptions) {
     super('vtex.rewriter@1.x', context, {
       ...options,
-      headers: { ...options.headers, 'cache-control': 'no-cache' },
+      headers: {
+        ...options.headers,
+        'cache-control': 'no-cache',
+        VtexIdclientAutCookie: context.authToken,
+      },
       retries: 5,
       timeout: 10000,
     })


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adds authentication token in the request for Rewriter mutations.


#### What problem is this solving?

Since Rewriter added authentication in its mutation the plugin started to break due to missing authentication token.

#### How should this be manually tested?

Follow the readme to build the plugin and link it using `vtex plugins link`
Using a csv file as an example run: `vtex redirects import redirects.csv`
Then delete the redirects uploaded: `vtex redirects delete redirects.csv`

#### Screenshots or example usage

<img width="843" height="80" alt="image" src="https://github.com/user-attachments/assets/c185c3d6-bd76-401b-8a4f-b6aa6eebac94" />

<img width="808" height="78" alt="image" src="https://github.com/user-attachments/assets/3f928bbc-4093-4417-9d61-f876e817e1b7" />


#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [X] Update `CHANGELOG.md`